### PR TITLE
changed base image of Dockerfiles from 'latest' to '5.0.1'

### DIFF
--- a/AMQP/rabbitmq/gateway/Dockerfile
+++ b/AMQP/rabbitmq/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM kaazing/enterprise-gateway:latest
+FROM kaazing/enterprise-gateway:5.0.1
 
 # Generate Keystore entry for kaazing.example.com
 

--- a/JMS/activemq/broker/Dockerfile
+++ b/JMS/activemq/broker/Dockerfile
@@ -1,5 +1,5 @@
 # There is no official image of activemq yet so we will use the one that ships with the gateway
-FROM kaazing/enterprise-gateway:latest
+FROM kaazing/enterprise-gateway:5.0.1
 
 CMD ["java","-jar","brokers/apache-activemq-5.10.0/bin/activemq.jar","start"]
 

--- a/JMS/activemq/gateway/Dockerfile
+++ b/JMS/activemq/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM kaazing/enterprise-gateway:latest
+FROM kaazing/enterprise-gateway:5.0.1
 
 # Generate Keystore entry for kaazing.example.com
 

--- a/broadcast/netcat/gateway/Dockerfile
+++ b/broadcast/netcat/gateway/Dockerfile
@@ -1,3 +1,3 @@
-FROM kaazing/enterprise-gateway:latest
+FROM kaazing/enterprise-gateway:5.0.1
 
 COPY broadcast-gateway-config.xml conf/gateway-config.xml

--- a/enterprise-shield/AMQP/rabbitmq/dmz/Dockerfile
+++ b/enterprise-shield/AMQP/rabbitmq/dmz/Dockerfile
@@ -1,4 +1,4 @@
-FROM kaazing/enterprise-gateway:latest
+FROM kaazing/enterprise-gateway:5.0.1
 
 # Generate Keystore entry for kaazing.example.com
 

--- a/enterprise-shield/AMQP/rabbitmq/internal/Dockerfile
+++ b/enterprise-shield/AMQP/rabbitmq/internal/Dockerfile
@@ -1,4 +1,4 @@
-FROM kaazing/enterprise-gateway:latest
+FROM kaazing/enterprise-gateway:5.0.1
 
 # Generate Keystore entry for kaazing.example.com
 

--- a/user-auth/file/gateway/Dockerfile
+++ b/user-auth/file/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM kaazing/enterprise-gateway:latest
+FROM kaazing/enterprise-gateway:5.0.1
 
 # Generate Keystore entry for kaazing.example.com
 

--- a/wss/echo/gateway/Dockerfile
+++ b/wss/echo/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM kaazing/enterprise-gateway:latest
+FROM kaazing/enterprise-gateway:5.0.1
 
 # Generate Keystore entry for kaazing.example.com
 


### PR DESCRIPTION
Meant to fix the following issue when running `docker-compose up -d` on various tutorials:

`Step 6 : RUN git clone https://github.com/kaazing/javascript.client.tutorials ./web/javascript.client.tutorials
`
`
 ---> Running in a764ee17247f
`
`
/bin/sh: 1: git: not found
`
`
ERROR: Service 'gateway' failed to build: The command '/bin/sh -c git clone https://github.com/kaazing/javascript.client.tutorials ./web/javascript.client.tutorials' returned a non-zero code: 127
`